### PR TITLE
Skip apt if 'no-apt' flag passed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,15 @@ function error {
   exit 1
 }
 
-sudo apt update
-
-#Installing dependencies
-sudo apt -y install libfontconfig-dev qt5-default automake mercurial libtool libfreeimage-dev \
-libopenal-dev libpango1.0-dev libsndfile-dev libudev-dev libtiff5-dev libwebp-dev libasound2-dev \
-libaudio-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxss-dev libesd0-dev \
-freeglut3-dev libmodplug-dev libsmpeg-dev libjpeg-dev libogg-dev libvorbis-dev libvorbisfile3 libcurl4 cmake aria2 lolcat figlet || error "Failed to install dependencies"
+if [ -z "$1" ] || [ "$1" != 'no-apt' ];then
+  sudo apt update
+  
+  #Installing dependencies
+  sudo apt -y install libfontconfig-dev qt5-default automake mercurial libtool libfreeimage-dev \
+  libopenal-dev libpango1.0-dev libsndfile-dev libudev-dev libtiff5-dev libwebp-dev libasound2-dev \
+  libaudio-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxss-dev libesd0-dev \
+  freeglut3-dev libmodplug-dev libsmpeg-dev libjpeg-dev libogg-dev libvorbis-dev libvorbisfile3 libcurl4 cmake aria2 lolcat figlet || error "Failed to install dependencies"
+fi
 
 #Downloading SDK libraries
 figlet Downloading SDL libraries | lolcat


### PR DESCRIPTION
Pi-Apps installs the necessary packages so your script doesn't need to.
Adding a flag to your script will allow Pi-Apps to tell it to skip the apt portion, preventing this error log:
```
Making scripts executable...
Running install script...

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Obj:1 http://deb.debian.org/debian buster-backports InRelease
Obj:2 http://ftp.debian.org/debian stretch-backports InRelease
Obj:3 http://archive.raspberrypi.org/debian buster InRelease
Obj:4 http://ppa.launchpad.net/linuxuprising/java/ubuntu bionic InRelease
Obj:5 https://download.docker.com/linux/raspbian buster InRelease
Obj:6 http://raspbian.raspberrypi.org/raspbian buster InRelease
Leyendo lista de paquetes...
Creando <E1>rbol de dependencias...
Leyendo la informaci<F3>n de estado...
Se pueden actualizar 23 paquetes. Ejecute <AB>apt list --upgradable<BB> para verlos.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

E: No se pudo bloquear /var/lib/dpkg/lock-frontend - open (11: Recurso no disponible temporalmente)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
Failed to install dependencies
Failed to run install script :(
```